### PR TITLE
Add login and logout session management

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,0 +1,49 @@
+<?php
+session_start();
+
+$host = 'localhost';
+$dbname = 'xs980818_noralive';
+$user = 'xs980818_yasu';
+$password = 'pokopixgvp';
+
+$conn = new mysqli($host, $user, $password, $dbname);
+if ($conn->connect_error) {
+    die('接続失敗: ' . $conn->connect_error);
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $pass = $_POST['password'] ?? '';
+
+    $stmt = $conn->prepare('SELECT id, password FROM users WHERE email = ?');
+    $stmt->bind_param('s', $email);
+    $stmt->execute();
+    $stmt->bind_result($userId, $hash);
+    if ($stmt->fetch() && password_verify($pass, $hash)) {
+        $_SESSION['user_id'] = $userId;
+        header('Location: index.html');
+        exit;
+    } else {
+        $error = 'メールアドレスまたはパスワードが違います。';
+    }
+    $stmt->close();
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>ログイン</title>
+</head>
+<body>
+<?php if ($error): ?>
+    <p><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></p>
+<?php endif; ?>
+<form method="post" action="login.php">
+    <label>メールアドレス: <input type="email" name="email" required></label><br>
+    <label>パスワード: <input type="password" name="password" required></label><br>
+    <button type="submit">ログイン</button>
+</form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,9 @@
+<?php
+session_start();
+
+$_SESSION = [];
+session_destroy();
+
+header('Location: login.php');
+exit;
+?>


### PR DESCRIPTION
## Summary
- Implement `login.php` with a form that verifies credentials via `password_verify` and sets `$_SESSION['user_id']` on success.
- Add `logout.php` to destroy the session and redirect back to the login page.

## Testing
- `php -l login.php`
- `php -l logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68a40b95dc0c832e9cc053bbcae569ff