### PR TITLE
Add band listing and detail pages

### DIFF
--- a/bands/index.php
+++ b/bands/index.php
@@ -1,0 +1,55 @@
+<?php
+$host = 'localhost';
+$dbname = 'xs980818_noralive';
+$username = 'xs980818_yasu';
+$password = 'pokopixgvp';
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8mb4", $username, $password);
+    $sql = "SELECT * FROM bands ORDER BY created_at DESC";
+    $stmt = $pdo->query($sql);
+    $bands = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    echo "エラー: " . $e->getMessage();
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>バンド一覧</title>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+        th, td {
+            border: 1px solid #000;
+            padding: 8px;
+            text-align: left;
+        }
+    </style>
+</head>
+<body>
+<h1>バンド一覧</h1>
+<table>
+    <tr>
+        <th>ID</th>
+        <th>バンド名</th>
+        <th>よみ</th>
+        <th>所属団体</th>
+        <th>登録日</th>
+    </tr>
+    <?php foreach ($bands as $band): ?>
+    <tr>
+        <td><?= htmlspecialchars($band['id']) ?></td>
+        <td><a href="show.php?id=<?= urlencode($band['id']) ?>"><?= htmlspecialchars($band['name']) ?></a></td>
+        <td><?= htmlspecialchars($band['kana']) ?></td>
+        <td><?= htmlspecialchars($band['organization']) ?></td>
+        <td><?= htmlspecialchars($band['created_at']) ?></td>
+    </tr>
+    <?php endforeach; ?>
+</table>
+</body>
+</html>

--- a/bands/show.php
+++ b/bands/show.php
@@ -1,0 +1,44 @@
+<?php
+$host = 'localhost';
+$dbname = 'xs980818_noralive';
+$username = 'xs980818_yasu';
+$password = 'pokopixgvp';
+
+$id = $_GET['id'] ?? null;
+if ($id === null) {
+    echo 'IDが指定されていません';
+    exit;
+}
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8mb4", $username, $password);
+    $stmt = $pdo->prepare("SELECT * FROM bands WHERE id = :id");
+    $stmt->execute([':id' => $id]);
+    $band = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$band) {
+        echo 'バンドが見つかりません';
+        exit;
+    }
+} catch (PDOException $e) {
+    echo "エラー: " . $e->getMessage();
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>バンド詳細</title>
+</head>
+<body>
+<h1>バンド詳細</h1>
+<ul>
+    <li>ID: <?= htmlspecialchars($band['id']) ?></li>
+    <li>バンド名: <?= htmlspecialchars($band['name']) ?></li>
+    <li>よみ: <?= htmlspecialchars($band['kana']) ?></li>
+    <li>所属団体: <?= htmlspecialchars($band['organization']) ?></li>
+    <li>登録日: <?= htmlspecialchars($band['created_at']) ?></li>
+</ul>
+<p><a href="index.php">一覧に戻る</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- List all bands ordered by creation date with links to detail pages
- Display individual band details based on ID parameter

## Testing
- `php -l bands/index.php`
- `php -l bands/show.php`


------
https://chatgpt.com/codex/tasks/task_e_68a40b900e4c832e8d3bb96e539ee99d